### PR TITLE
Simplify most things (remove connect)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     'react/prop-types': 'off',
     'react/no-unused-state': 'off',
     'react/forbid-prop-types': 'off',
+    'react/no-render-return-value': 'off',
 
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' } ],
     'jsx-a11y/label-has-for': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
     'react/no-multi-comp': 'off',
     'react/prop-types': 'off',
     'react/no-unused-state': 'off',
-    'react/forbid-prop-types': 'off',
     'react/no-render-return-value': 'off',
 
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' } ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     'react/no-multi-comp': 'off',
     'react/prop-types': 'off',
     'react/no-unused-state': 'off',
+    'react/forbid-prop-types': 'off',
 
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' } ],
     'jsx-a11y/label-has-for': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     webextensions: true,
   },
   rules: {
+    'comma-dangle': ['error', 'never'],
     'curly': 'off',
     'no-else-return': 'off',
     'no-unexpected-multiline': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,9 +21,9 @@ module.exports = {
 
     'react/destructuring-assignment': 'off',
     'react/no-multi-comp': 'off',
-    'react/prop-types': 'off',
-    'react/no-unused-state': 'off',
     'react/no-render-return-value': 'off',
+    'react/no-unused-state': 'off',
+    'react/prop-types': 'off',
 
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' } ],
     'jsx-a11y/label-has-for': 'off',

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -13,7 +13,7 @@
     "48": "spur1.png"
   },
   "chrome_url_overrides" : {
-    "newtab": "app.html"
+    "newtab": "index.html"
   },
   "permissions": [
     "storage"

--- a/assets/seeds.json
+++ b/assets/seeds.json
@@ -1,103 +1,103 @@
 [
   {
-    "quote"    : "A monk told Joshu, “I have just entered this monastery. I beg you to teach me.”\n\nJoshu asked, “Have you eaten your rice porridge?”\n\nThe monk replied, “I have.”\n\n“Then,” said Joshu, “Go and wash your bowl.”",
+    "text"     : "A monk told Joshu, “I have just entered this monastery. I beg you to teach me.”\n\nJoshu asked, “Have you eaten your rice porridge?”\n\nThe monk replied, “I have.”\n\n“Then,” said Joshu, “Go and wash your bowl.”",
     "author"   : "無門慧開",
     "category" : "Mindset",
     "url"      : "http://mnmlist.com/wash-your-bowl/"
   },
   {
-    "quote"    : "People who are unable to motivate themselves must be content with mediocrity, no matter how impressive their other talents.",
+    "text"     : "People who are unable to motivate themselves must be content with mediocrity, no matter how impressive their other talents.",
     "author"   : "Andrew Carnegie",
     "category" : "Mindset",
     "url"      : "https://www.brainyquote.com/quotes/andrew_carnegie_391523"
   },
   {
-    "quote"    : "The average person puts only 25% of his energy and ability into his work. The world takes off its hat to those who put in more than 50% of their capacity, and stands on its head for those few and far between souls who devote 100%.",
+    "text"     : "The average person puts only 25% of his energy and ability into his work. The world takes off its hat to those who put in more than 50% of their capacity, and stands on its head for those few and far between souls who devote 100%.",
     "author"   : "Andrew Carnegie",
     "category" : "Mindset",
     "url"      : "https://hear.ceoblognation.com/2012/10/16/the-men-who-built-america-andrew-carnegie/"
   },
   {
-    "quote"    : "The man who acquires the ability to take full possession of his own mind may take possession of anything else to which he is justly entitled.",
+    "text"     : "The man who acquires the ability to take full possession of his own mind may take possession of anything else to which he is justly entitled.",
     "author"   : "Andrew Carnegie",
     "category" : "Mindset",
     "url"      : "https://hear.ceoblognation.com/2012/10/16/the-men-who-built-america-andrew-carnegie/"
   },
   {
-    "quote"    : "...People will tell you to do what makes you happy, but a lot of this has been hard work, and I’m not always happy. And I don’t think you should do just what makes you happy. I think you should do what makes you great. Do what’s uncomfortable, and scary, and hard, but pays off in the long run.",
+    "text"     : "...People will tell you to do what makes you happy, but a lot of this has been hard work, and I’m not always happy. And I don’t think you should do just what makes you happy. I think you should do what makes you great. Do what’s uncomfortable, and scary, and hard, but pays off in the long run.",
     "author"   : "Charlie Day",
     "category" : "Mindset",
     "url"      : "https://motivationmentalist.com/2016/12/15/do-what-makes-you-great-charlie-day-motivational-video/"
   },
   {
-    "quote"    : "Success isn't always about “greatness,” it's about consistency. Consistent hard work gains success. Greatness will come.",
+    "text"     : "Success isn't always about “greatness,” it's about consistency. Consistent hard work gains success. Greatness will come.",
     "author"   : "Dwayne “The Rock” Johnson",
     "category" : "Mindset",
     "url"      : "https://twitter.com/therock/status/548846125529055232"
   },
   {
-    "quote"    : "Everybody pities the weak; jealousy you have to earn.",
+    "text"     : "Everybody pities the weak; jealousy you have to earn.",
     "author"   : "Arnold Schwarzenegger",
     "category" : "Mindset",
     "url"      : "https://www.goodreads.com/quotes/152890-everybody-pities-the-weak-jealousy-you-have-to-earn"
   },
   {
-    "quote"    : "You'll never change your life until you change something you do daily. The secret of your success is found in your daily routine.",
+    "text"     : "You'll never change your life until you change something you do daily. The secret of your success is found in your daily routine.",
     "author"   : "John C. Maxwell",
     "category" : "Mindset",
     "url"      : "https://www.johnmaxwell.com/blog/it-all-comes-down-to-what-you-do-daily/"
   },
   {
-    "quote"    : "...If we’re facing in the right direction, all we have to do is keep on walking.",
+    "text"     : "...If we’re facing in the right direction, all we have to do is keep on walking.",
     "author"   : "Joseph Goldstein",
     "category" : "Mindset",
     "url"      : "https://fakebuddhaquotes.com/if-we-are-facing-in-the-right-direction-all-we-have-to-do-is-keep-on-walking/"
   },
   {
-    "quote"    : "Argue for your limitations and, sure enough, they're yours.",
+    "text"     : "Argue for your limitations and, sure enough, they're yours.",
     "author"   : "Richard Bach",
     "category" : "Mindset",
     "url"      : "https://www.goodreads.com/quotes/5832-argue-for-your-limitations-and-sure-enough-they-re-yours"
   },
   {
-    "quote"    : "Losers spend way too much time being pissed off by the problem rather than moving into the positive state of mind and getting on with building the solution... Losers tell made up stories to themselves and those around them about the problem.\n\nThis storytelling takes up a lot of time and sucks away all the energy that could be channeled into coming up with the solution.",
+    "text"     : "Losers spend way too much time being pissed off by the problem rather than moving into the positive state of mind and getting on with building the solution... Losers tell made up stories to themselves and those around them about the problem.\n\nThis storytelling takes up a lot of time and sucks away all the energy that could be channeled into coming up with the solution.",
     "author"   : "Tim Denning",
     "category" : "Mindset",
     "url"      : "https://addicted2success.com/success-advice/how-losers-are-created-and-how-to-avoid-becoming-one/"
   },
   {
-    "quote"    : "Either you run the day or the day runs you.",
+    "text"     : "Either you run the day or the day runs you.",
     "author"   : "Jim Rohn",
     "category" : "Mindset"
   },
   {
-    "quote"    : "The secret of getting ahead is getting started.",
+    "text"     : "The secret of getting ahead is getting started.",
     "author"   : "Mark Twain",
     "category" : "Mindset"
   },
   {
-    "quote"    : "Try not to become a person of success, but rather try to become a person of value.",
+    "text"     : "Try not to become a person of success, but rather try to become a person of value.",
     "author"   : "Albert Einstein",
     "category" : "Mindset"
   },
   {
-    "quote"    : "The difference between winning and losing is most often not quitting.",
+    "text"     : "The difference between winning and losing is most often not quitting.",
     "author"   : "Walt Disney",
     "category" : "Mindset"
   },
   {
-    "quote"    : "You'll never plow a field by turning it over in your mind.",
+    "text"     : "You'll never plow a field by turning it over in your mind.",
     "author"   : "Irish proverb",
     "category" : "Mindset"
   },
   {
-    "quote"    : "If the wind will not serve, take to the oars.",
+    "text"     : "If the wind will not serve, take to the oars.",
     "author"   : "Latin proverb",
     "category" : "Mindset",
     "url"      : "https://philosiblog.com/2013/04/29/if-the-wind-will-not-serve-take-to-the-oars/"
   },
   {
-    "quote"    : "Skills can be taught. Character you either have or don't have. Bigfoot understood that there are two types of people in the world: those who do what they say they're going to do—and everyone else.",
+    "text"     : "Skills can be taught. Character you either have or don't have. Bigfoot understood that there are two types of people in the world: those who do what they say they're going to do—and everyone else.",
     "author"   : "Anthony Bourdain",
     "category" : "Mindset",
     "url"      : "https://archive.org/stream/Anthony_Bourdain_Kitchen_Confidential/Anthony_Bourdain_Kitchen_Confidential_djvu.txt"

--- a/assets/styles/app/index_card.scss
+++ b/assets/styles/app/index_card.scss
@@ -16,7 +16,7 @@ $vspace: 20px;
     background-color: $gray-7;
   }
 
-  .quoteBox--quote {
+  .quoteBox--text {
     position: relative; // for before & after
     margin-top: $vspace;
     margin-bottom: $vspace * 2;

--- a/assets/styles/app/index_card_dark.scss
+++ b/assets/styles/app/index_card_dark.scss
@@ -9,7 +9,7 @@
     border-color: $gray-2;
   }
 
-  .quoteBox--quote {
+  .quoteBox--text {
     color: $gray-4;
 
     &:before, &:after {

--- a/assets/styles/options/style.scss
+++ b/assets/styles/options/style.scss
@@ -83,7 +83,7 @@ p {
   }
 
   &:focus {
-    padding-left: $padding - 3px;
+    padding: $padding - 3px;
   }
 
   &:focus,

--- a/assets/styles/options/style.scss
+++ b/assets/styles/options/style.scss
@@ -183,6 +183,12 @@ p {
   }
 }
 
+.quoteForm--field {
+  &:not(:last-child) {
+    margin-bottom: 20px;
+  }
+}
+
 .quoteForm--label {
   font: 500 14px $basic-font-stack;
   color: $gray-3;
@@ -190,7 +196,7 @@ p {
   margin-bottom: 6px;
 }
 
-.quoteForm--field {
+.quoteForm--input {
   @extend %basic-type;
   display: block;
   box-sizing: border-box;
@@ -198,13 +204,9 @@ p {
   border: 1px solid $gray-4;
   border-radius: 2px;
   padding: 6px;
-
-  &:not(:last-child) {
-    margin-bottom: 20px;
-  }
 }
 
-.quoteForm--field-textarea {
+.quoteForm--input-textarea {
   height: 150px;
 }
 

--- a/assets/styles/options/style.scss
+++ b/assets/styles/options/style.scss
@@ -70,14 +70,12 @@ p {
   text-align: left;
   border-radius: 2px;
 
-  > div {
+  > .truncatedText {
     flex-grow: 1;
   }
 
-  > .svg-inline--fa {
+  > .editQuoteButton--pencil {
     display: none;
-    color: $gray-3;
-    margin-right: 4px;
   }
 
   & + & {
@@ -87,14 +85,14 @@ p {
   &:focus {
     padding-left: $padding - 3px;
   }
-  
+
   &:focus,
   &:hover {
-    > div {
+    > .truncatedText {
       margin-right: 8px;
     }
 
-    > .svg-inline--fa {
+    > .editQuoteButton--pencil {
       display: block;
     }
   }
@@ -104,11 +102,17 @@ p {
   @extend %icon-margin;
   @include foreground-tints($gray-4);
 
+  align-items: center;
   border: 2px dashed currentColor;
 
   &:focus {
     padding-left: 6px;
   }
+}
+
+.editQuoteButton--pencil {
+  color: $gray-3;
+  margin-right: 4px;
 }
 
 .truncatedText {

--- a/assets/styles/options/style.scss
+++ b/assets/styles/options/style.scss
@@ -61,33 +61,42 @@ p {
   @include background-tints($gray-6);
   @include focus-ring('border');
 
+  $padding: 12px;
+
+  display: flex;
   width: 100%;
   height: 42px;
-  padding: 12px;
+  padding: $padding;
   text-align: left;
   border-radius: 2px;
 
-  &:focus {
-    padding-left: 8px - 3px;
+  > div {
+    flex-grow: 1;
+  }
+
+  > .svg-inline--fa {
+    display: none;
+    color: $gray-3;
+    margin-right: 4px;
   }
 
   & + & {
     margin-top: 10px;
   }
-}
 
-.editQuoteButton-is-hovered {
-  display: flex;
-  align-items: center;
-
-  > div:first-child {
-    flex-grow: 1;
-    margin-right: 8px;
+  &:focus {
+    padding-left: $padding - 3px;
   }
+  
+  &:focus,
+  &:hover {
+    > div {
+      margin-right: 8px;
+    }
 
-  .svg-inline--fa {
-    color: $gray-3;
-    margin-right: 4px;
+    > .svg-inline--fa {
+      display: block;
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1254,11 +1254,6 @@
         "commander": "^2.11.0"
       }
     },
-    "arity-n": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
-      "integrity": "sha1-2edrEXM+CFacCEeuezmyhgswt0U="
-    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2429,14 +2424,6 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
-    },
-    "compose-function": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/compose-function/-/compose-function-3.0.3.tgz",
-      "integrity": "sha1-ntZ18TzFRQHTCVCkhv9qe6OrGF8=",
-      "requires": {
-        "arity-n": "^1.0.4"
-      }
     },
     "compress-commons": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1254,6 +1254,11 @@
         "commander": "^2.11.0"
       }
     },
+    "arity-n": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
+      "integrity": "sha1-2edrEXM+CFacCEeuezmyhgswt0U="
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2424,6 +2429,14 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
+    },
+    "compose-function": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/compose-function/-/compose-function-3.0.3.tgz",
+      "integrity": "sha1-ntZ18TzFRQHTCVCkhv9qe6OrGF8=",
+      "requires": {
+        "arity-n": "^1.0.4"
+      }
     },
     "compress-commons": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@fortawesome/free-solid-svg-icons": "^5.7.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "classnames": "^2.2.6",
-    "compose-function": "^3.0.3",
     "lodash.sample": "^4.2.1",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.7.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "classnames": "^2.2.6",
+    "compose-function": "^3.0.3",
     "lodash.sample": "^4.2.1",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@fortawesome/react-fontawesome": "^0.1.4",
     "classnames": "^2.2.6",
     "lodash.sample": "^4.2.1",
-    "prop-types": "^15.7.2",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "react-modal": "^3.8.1",

--- a/src/actions.js
+++ b/src/actions.js
@@ -28,6 +28,9 @@ export const updateSettings = settings => (
 export const setActiveQuote = quote => (
   { type: 'SET_ACTIVE_QUOTE', payload: quote }
 )
+export const patchActiveQuote = patch => (
+  { type: 'PATCH_ACTIVE_QUOTE', payload: patch }
+)
 export const setNewActiveQuote = () => (
   { type: 'SET_NEW_ACTIVE_QUOTE' }
 )

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,3 +1,4 @@
+// modal-only
 export const openModal = () => (
   { type: 'OPEN_MODAL' }
 )
@@ -6,25 +7,31 @@ export const closeModal = () => (
 )
 
 
+// quote record list
 export const saveQuoteRecords = () => (
   { type: 'SAVE_QUOTE_RECORDS' }
 )
+
 export const updateQuoteRecords = quoteRecords => (
   { type: 'UPDATE_QUOTE_RECORDS', payload: quoteRecords }
 )
+
 export const putQuoteRecord = quote => (
   { type: 'PUT_QUOTE_RECORD', payload: quote }
 )
+
 export const deleteQuoteRecord = id => (
   { type: 'DELETE_QUOTE_RECORD', payload: id }
 )
 
 
+// settings
 export const updateSettings = settings => (
   { type: 'UPDATE_SETTINGS', payload: settings }
 )
 
 
+// edit form
 export const setActiveQuote = quote => (
   { type: 'SET_ACTIVE_QUOTE', payload: quote }
 )

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,8 +1,8 @@
-export const openEditModal = () => (
-  { type: 'OPEN_EDIT_MODAL' }
+export const openModal = () => (
+  { type: 'OPEN_MODAL' }
 )
-export const closeEditModal = () => (
-  { type: 'CLOSE_EDIT_MODAL' }
+export const closeModal = () => (
+  { type: 'CLOSE_MODAL' }
 )
 
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -20,8 +20,8 @@ export const saveQuoteRecords = () => (
 export const updateQuoteRecords = quoteRecords => (
   { type: 'UPDATE_QUOTE_RECORDS', payload: quoteRecords }
 )
-export const updateQuoteRecord = quote => (
-  { type: 'UPDATE_QUOTE_RECORD', payload: quote }
+export const putQuoteRecord = quote => (
+  { type: 'PUT_QUOTE_RECORD', payload: quote }
 )
 export const deleteQuoteRecord = id => (
   { type: 'DELETE_QUOTE_RECORD', payload: id }

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,11 +1,3 @@
-export const openAddModal = () => (
-  { type: 'OPEN_ADD_MODAL' }
-)
-export const closeAddModal = () => (
-  { type: 'CLOSE_ADD_MODAL' }
-)
-
-
 export const openEditModal = () => (
   { type: 'OPEN_EDIT_MODAL' }
 )

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,4 +1,6 @@
-// modal-only
+/*
+ * modal-only
+ */
 export const openModal = () => (
   { type: 'OPEN_MODAL' }
 )
@@ -7,7 +9,9 @@ export const closeModal = () => (
 )
 
 
-// quote record list
+/*
+ * quote record list
+ */
 export const saveQuotes = () => (
   { type: 'SAVE_QUOTES' }
 )
@@ -25,13 +29,17 @@ export const deleteQuote = id => (
 )
 
 
-// settings
+/*
+ * settings
+ */
 export const updateSettings = settings => (
   { type: 'UPDATE_SETTINGS', payload: settings }
 )
 
 
-// edit form
+/*
+ * edit form
+ */
 export const setActiveQuote = quote => (
   { type: 'SET_ACTIVE_QUOTE', payload: quote }
 )

--- a/src/actions.js
+++ b/src/actions.js
@@ -8,20 +8,20 @@ export const closeModal = () => (
 
 
 // quote record list
-export const saveQuoteRecords = () => (
-  { type: 'SAVE_QUOTE_RECORDS' }
+export const saveQuotes = () => (
+  { type: 'SAVE_QUOTES' }
 )
 
-export const updateQuoteRecords = quoteRecords => (
-  { type: 'UPDATE_QUOTE_RECORDS', payload: quoteRecords }
+export const updateQuotes = quotes => (
+  { type: 'UPDATE_QUOTES', payload: quotes }
 )
 
-export const putQuoteRecord = quote => (
-  { type: 'PUT_QUOTE_RECORD', payload: quote }
+export const putQuote = quote => (
+  { type: 'PUT_QUOTE', payload: quote }
 )
 
-export const deleteQuoteRecord = id => (
-  { type: 'DELETE_QUOTE_RECORD', payload: id }
+export const deleteQuote = id => (
+  { type: 'DELETE_QUOTE', payload: id }
 )
 
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -43,8 +43,8 @@ export const updateSettings = settings => (
 export const setActiveQuote = quote => (
   { type: 'SET_ACTIVE_QUOTE', payload: quote }
 )
-export const patchActiveQuote = patch => (
-  { type: 'PATCH_ACTIVE_QUOTE', payload: patch }
+export const patchActiveQuote = (key, value) => (
+  { type: 'PATCH_ACTIVE_QUOTE', payload: { [key]: value } }
 )
 export const setNewActiveQuote = () => (
   { type: 'SET_NEW_ACTIVE_QUOTE' }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,7 +1,8 @@
-import React, { Component } from 'react'
+import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import classNames from 'classnames'
 import sample from 'lodash.sample'
+import compose from 'compose-function'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBox } from '@fortawesome/free-solid-svg-icons/faBox'
@@ -114,43 +115,27 @@ const QuoteBox = ({ text, author, url, category, expanded, toggle }) => {
 /*
  * Loads a quote and renders the <QuoteBox />.
  */
-class AppRoot extends Component {
-  constructor(props) {
-    super(props)
+const AppRoot = () => {
+  const [expanded, setExpanded] = useState(false)
+  const [quote, setQuote] = useState({})
+  const loaded = !!quote.text
 
-    this.state = {
-      text: undefined,
-      author: undefined,
-      url: undefined,
-      category: undefined,
-      expanded: false
-    }
-  }
+  useEffect(() => {
+    if (!loaded) loadQuotes().then(compose(setQuote, sample))
+  })
 
-  componentDidMount() {
-    loadQuotes().then(quotes => this.setState(sample(quotes)))
-  }
-
-  toggle = () => {
-    this.setState(old => ({ expanded: !old.expanded }))
-  }
-
-  render() {
-    if (!this.state.text) return null
-
-    return [
-      <OptionsButton key="opts-btn" />,
-      <QuoteBox
-        key="quote-box"
-        text={this.state.text}
-        author={this.state.author}
-        url={this.state.url}
-        category={this.state.category}
-        expanded={this.state.expanded}
-        toggle={this.toggle}
-      />
-    ]
-  }
+  return loaded ? [
+    <OptionsButton key="opts-btn" />,
+    <QuoteBox
+      key="quote-box"
+      text={quote.text}
+      author={quote.author}
+      url={quote.url}
+      category={quote.category}
+      expanded={expanded}
+      toggle={() => setExpanded(!expanded)}
+    />
+  ] : null
 }
 
 async function main() {

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -128,7 +128,7 @@ class AppRoot extends Component {
   }
 
   componentDidMount() {
-    loadQuotes().then(qs => this.setState(sample(qs)))
+    loadQuotes().then(quotes => this.setState(sample(quotes)))
   }
 
   toggle = () => {

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -16,11 +16,11 @@ polyfillBrowser()
 /*
  * The main text of a quote.
  */
-const Quote = ({ quote }) => {
-  const size = 160 * (1 / (quote.length ** 0.3))
+const Quote = ({ text }) => {
+  const size = 160 * (1 / (text.length ** 0.3))
   return (
-    <div className="quoteBox--quote" style={{ fontSize: `${size}px` }}>
-      {quote}
+    <div className="quoteBox--text" style={{ fontSize: `${size}px` }}>
+      {text}
     </div>
   )
 }
@@ -92,7 +92,7 @@ const VerticalToggle = ({ up, handleClick }) => {
 /*
  * A displayed quote, with author, etc.
  */
-const QuoteBox = ({ quote, author, url, category, expanded, toggle }) => {
+const QuoteBox = ({ text, author, url, category, expanded, toggle }) => {
   const classes = classNames(
     'quoteBox', {
       'quoteBox-is-expanded': expanded,
@@ -101,7 +101,7 @@ const QuoteBox = ({ quote, author, url, category, expanded, toggle }) => {
   )
   return (
     <div className={classes}>
-      <Quote quote={quote} />
+      <Quote text={text} />
       <Author author={author} />
       <Rule />
       {url && <Info url={url} />}
@@ -119,7 +119,7 @@ class AppRoot extends Component {
     super(props)
 
     this.state = {
-      quote: undefined,
+      text: undefined,
       author: undefined,
       url: undefined,
       category: undefined,
@@ -136,13 +136,13 @@ class AppRoot extends Component {
   }
 
   render() {
-    if (!this.state.quote) return null
+    if (!this.state.text) return null
 
     return [
       <OptionsButton key="opts-btn" />,
       <QuoteBox
         key="quote-box"
-        quote={this.state.quote}
+        text={this.state.text}
         author={this.state.author}
         url={this.state.url}
         category={this.state.category}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -12,7 +12,6 @@ import { faGlobeAmericas } from '@fortawesome/free-solid-svg-icons/faGlobeAmeric
 import { loadSettings, loadQuotes, polyfillBrowser } from './util'
 import 'Styles/app/style.scss'
 
-polyfillBrowser()
 
 /*
  * The main text of a quote.
@@ -139,6 +138,7 @@ const AppRoot = () => {
 }
 
 async function main() {
+  polyfillBrowser()
   const settings = await loadSettings()
   window.root.classList.add(settings.theme)
   ReactDOM.render(<AppRoot />, window.root)

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import classNames from 'classnames'
 import sample from 'lodash.sample'
-import compose from 'compose-function'
+import { compose } from 'redux'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBox } from '@fortawesome/free-solid-svg-icons/faBox'

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -79,7 +79,7 @@ const VerticalToggle = ({ up, handleClick }) => {
   const classes = classNames(
     'verticalToggle', {
       'verticalToggle-is-up': up,
-      'verticalToggle-is-down': !up,
+      'verticalToggle-is-down': !up
     },
   )
   return (
@@ -96,7 +96,7 @@ const QuoteBox = ({ text, author, url, category, expanded, toggle }) => {
   const classes = classNames(
     'quoteBox', {
       'quoteBox-is-expanded': expanded,
-      'quoteBox-is-collapsed': !expanded,
+      'quoteBox-is-collapsed': !expanded
     },
   )
   return (
@@ -123,7 +123,7 @@ class AppRoot extends Component {
       author: undefined,
       url: undefined,
       category: undefined,
-      expanded: false,
+      expanded: false
     }
   }
 
@@ -148,7 +148,7 @@ class AppRoot extends Component {
         category={this.state.category}
         expanded={this.state.expanded}
         toggle={this.toggle}
-      />,
+      />
     ]
   }
 }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -140,9 +140,8 @@ const AppRoot = () => {
 
 async function main() {
   const settings = await loadSettings()
-  const rootEl = document.getElementById('root')
-  rootEl.classList.add(settings.theme)
-  ReactDOM.render(<AppRoot />, rootEl)
+  window.root.classList.add(settings.theme)
+  ReactDOM.render(<AppRoot />, window.root)
 }
 
 main()

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import Modal from 'react-modal'
 import { createStore } from 'redux'
@@ -282,28 +282,24 @@ const EditModal = () => {
 /*
  * Loads the options page and holds state.
  */
-class AppRoot extends Component {
-  componentDidMount() {
-    // TODO: move this stuff into the store
+const AppRoot = () => {
+  const { settings, quoteRecords } = store.getState()
+  const fetched = settings.size && quoteRecords.size
+
+  useEffect(() => {
+    if (fetched) { return }
     loadSettings().then(compose2(dispatch, updateSettings))
     loadQuotes().then(compose2(dispatch, updateQuoteRecords))
-  }
+  })
 
-  render() {
-    const { settings, quoteRecords } = store.getState()
-    if (!settings.size || !quoteRecords.size) {
-      return null
-    }
-
-    return [
-      <OptionsPage
-        key="opts"
-        settings={settings}
-        quoteRecords={quoteRecords}
-      />,
-      <EditModal key="edit-modal" />,
-    ]
-  }
+  return fetched ? [
+    <OptionsPage
+      key="opts"
+      settings={settings}
+      quoteRecords={quoteRecords}
+    />,
+    <EditModal key="edit-modal" />,
+  ] : null
 }
 
 

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -16,7 +16,7 @@ import reducers from './reducers'
 import {
   setActiveQuote, setNewActiveQuote, patchActiveQuote,
   updateSettings, updateQuotes,
-  putQuote, deleteQuote, closeModal,
+  putQuote, deleteQuote, closeModal
 } from './actions'
 import { loadSettings, loadQuotes } from './util'
 
@@ -300,7 +300,7 @@ const AppRoot = () => {
       settings={settings}
       quotes={quotes}
     />,
-    <EditModal key="edit-modal" />,
+    <EditModal key="edit-modal" />
   ] : null
 }
 

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -17,7 +17,6 @@ import {
   setActiveQuote,
   setNewActiveQuote,
   patchActiveQuote,
-  openModal,
   closeModal,
   updateSettings,
   updateQuoteRecords,
@@ -73,7 +72,6 @@ class EditQuoteButton extends Component {
 
   handleClick = () => {
     dispatch(setActiveQuote(this.props.quoteRecord))
-    dispatch(openModal())
   }
 
   classes() {
@@ -113,7 +111,6 @@ class EditQuoteButton extends Component {
 class AddQuoteButton extends Component {
   handleClick = () => {
     dispatch(setNewActiveQuote())
-    dispatch(openModal())
   }
 
   render() {

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -1,7 +1,6 @@
-import React, { Component, useState } from 'react'
+import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import Modal from 'react-modal'
-import classNames from 'classnames'
 import { createStore } from 'redux'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -55,32 +54,19 @@ const SettingsSection = () => (
 /*
  * A clickable displayed quote. Includes a pencil icon on hover.
  */
-const EditQuoteButton = ({ quoteRecord }) => {
-  const [hover, setHover] = useState(false)
-  const classes = classNames(
-    'editQuoteButton', {
-      'editQuoteButton-is-hovered': hover,
-    },
-  )
-
-  return (
-    <button
-      className={classes}
-      type="button"
-      onClick={() => dispatch(setActiveQuote(quoteRecord))}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      onFocus={() => setHover(true)}
-      onBlur={() => setHover(false)}
-    >
-      <div className="truncatedText">
-        <span>{quoteRecord.quote}</span>
-        <span className="inlineAuthor">{` — ${quoteRecord.author}`}</span>
-      </div>
-      {hover ? <FontAwesomeIcon icon={faPencilAlt} /> : null}
-    </button>
-  )
-}
+const EditQuoteButton = ({ quoteRecord }) => (
+  <button
+    type="button"
+    className="editQuoteButton editQuoteButton-is-hovered"
+    onClick={() => dispatch(setActiveQuote(quoteRecord))}
+  >
+    <div className="truncatedText">
+      <span>{quoteRecord.quote}</span>
+      <span className="inlineAuthor">{` — ${quoteRecord.author}`}</span>
+    </div>
+    <FontAwesomeIcon icon={faPencilAlt} />
+  </button>
+)
 
 
 /*

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -236,6 +236,7 @@ const DeleteButton = ({ onClick }) => (
 )
 
 
+// TODO: make a function / HOC for the fields
 /*
  * A form for editing a quote. Buttons should be passed in as children.
  */

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -64,7 +64,7 @@ const EditQuoteButton = ({ quoteRecord }) => (
       <span>{quoteRecord.quote}</span>
       <span className="inlineAuthor">{` — ${quoteRecord.author}`}</span>
     </div>
-    <FontAwesomeIcon icon={faPencilAlt} />
+    <FontAwesomeIcon icon={faPencilAlt} className="editQuoteButton--pencil" />
   </button>
 )
 
@@ -72,24 +72,16 @@ const EditQuoteButton = ({ quoteRecord }) => (
 /*
  * Button for adding a new quote.
  */
-class AddQuoteButton extends Component {
-  handleClick = () => {
-    dispatch(setNewActiveQuote())
-  }
-
-  render() {
-    return (
-      <button
-        className="editQuoteButton editQuoteButton-add"
-        type="button"
-        onClick={this.handleClick}
-      >
-        <FontAwesomeIcon icon={faPlus} />
-        New quote…
-      </button>
-    )
-  }
-}
+const AddQuoteButton = () => (
+  <button
+    className="editQuoteButton editQuoteButton-add"
+    type="button"
+    onClick={() => dispatch(setNewActiveQuote())}
+  >
+    <FontAwesomeIcon icon={faPlus} />
+    New quote…
+  </button>
+)
 
 
 /*

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -474,24 +474,29 @@ const AppRoot = connect(
 
 class Provider extends Component {
   getChildContext() {
-    return {
-      store: this.props.store // This corresponds to the `store` passed in as a prop
-    };
+    return { store: this.props.store }
   }
+
   render() {
-    return this.props.children;
+    return this.props.children
   }
 }
 
 Provider.childContextTypes = {
-  store: PropTypes.object
+  store: PropTypes.object,
 }
 
 const rootEl = document.getElementById('root')
 const store = createStore(reducers)
 Modal.setAppElement('#root')
-ReactDOM.render((
-  <Provider store={store}>
-    <AppRoot />
-  </Provider>
-), rootEl)
+
+const render = () => {
+  ReactDOM.render((
+    <Provider store={store}>
+      <AppRoot />
+    </Provider>
+  ), rootEl)
+}
+
+render()
+store.subscribe(render)

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, useState } from 'react'
 import ReactDOM from 'react-dom'
 import Modal from 'react-modal'
 import classNames from 'classnames'
@@ -52,56 +52,34 @@ const SettingsSection = () => (
 )
 
 
-// TODO: use hooks for hover
 /*
  * A clickable displayed quote. Includes a pencil icon on hover.
  */
-class EditQuoteButton extends Component {
-  constructor(props) {
-    super(props)
-    this.state = { hover: false }
-  }
+const EditQuoteButton = ({ quoteRecord }) => {
+  const [hover, setHover] = useState(false)
+  const classes = classNames(
+    'editQuoteButton', {
+      'editQuoteButton-is-hovered': hover,
+    },
+  )
 
-  handleMouseEnter = () => {
-    this.setState({ hover: true })
-  }
-
-  handleMouseLeave = () => {
-    this.setState({ hover: false })
-  }
-
-  handleClick = () => {
-    dispatch(setActiveQuote(this.props.quoteRecord))
-  }
-
-  classes() {
-    return classNames(
-      'editQuoteButton', {
-        'editQuoteButton-is-hovered': this.state.hover,
-      },
-    )
-  }
-
-  render() {
-    const { quoteRecord: { quote, author } } = this.props
-    return (
-      <button
-        className={this.classes()}
-        type="button"
-        onClick={this.handleClick}
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}
-        onFocus={this.handleMouseEnter}
-        onBlur={this.handleMouseLeave}
-      >
-        <div className="truncatedText">
-          <span>{quote}</span>
-          <span className="inlineAuthor">{` — ${author}`}</span>
-        </div>
-        {this.state.hover ? <FontAwesomeIcon icon={faPencilAlt} /> : null}
-      </button>
-    )
-  }
+  return (
+    <button
+      className={classes}
+      type="button"
+      onClick={() => dispatch(setActiveQuote(quoteRecord))}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onFocus={() => setHover(true)}
+      onBlur={() => setHover(false)}
+    >
+      <div className="truncatedText">
+        <span>{quoteRecord.quote}</span>
+        <span className="inlineAuthor">{` — ${quoteRecord.author}`}</span>
+      </div>
+      {hover ? <FontAwesomeIcon icon={faPencilAlt} /> : null}
+    </button>
+  )
 }
 
 

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -18,8 +18,6 @@ import {
   setNewActiveQuote,
   openEditModal,
   closeEditModal,
-  openAddModal,
-  closeAddModal,
   updateSettings,
   updateQuoteRecords,
   putQuoteRecord,
@@ -113,7 +111,7 @@ class EditQuoteButton extends Component {
 class AddQuoteButton extends Component {
   handleClick = () => {
     store.dispatch(setNewActiveQuote())
-    store.dispatch(openAddModal())
+    store.dispatch(openEditModal())
   }
 
   render() {
@@ -281,73 +279,13 @@ const QuoteForm = ({ quote, author, url, category, children, handleChange }) => 
 )
 
 
-// TODO: delete AddQuoteModal
-/*
- * A modal for editing the clicked-on quote.
- */
-class AddQuoteModal extends Component {
-  closeModal = () => {
-    store.dispatch(closeAddModal())
-  }
-
-  handleChange = (field, event) => {
-    store.dispatch(
-      setActiveQuote(
-        Object.assign({}, this.props.quoteRecord, { [field]: event.target.value }),
-      ),
-    )
-  }
-
-  handleSave = () => {
-    store.dispatch(putQuoteRecord(store.getState().activeQuote))
-    // store.dispatch(saveQuoteRecords())
-    this.closeModal()
-  }
-
-  render() {
-    const { activeQuote, addModal: { isOpen } } = store.getState()
-    const { quote, author, url, category } = activeQuote
-
-    return (
-      <Modal
-        className="modal"
-        overlayClassName="modalOverlay"
-        isOpen={isOpen}
-        onRequestClose={this.closeModal}
-        contentLabel="Add Quote"
-      >
-        <h1 className="modal--heading">Add Quote</h1>
-        <hr className="modal--rule" />
-
-        <QuoteForm
-          quote={quote}
-          author={author}
-          url={url}
-          category={category}
-          handleChange={this.handleChange}
-        >
-          <button
-            type="button"
-            className="btn btn-save"
-            onClick={this.handleSave}
-          >
-            Save
-          </button>
-          <CancelButton onClick={this.closeModal} />
-        </QuoteForm>
-      </Modal>
-    )
-  }
-}
-
-
 // TODO: make this a presentational component?
 // TODO: add a prop for whether or not to allow delete
 // TODO: parameterize title
 /*
  * A modal for editing the clicked-on quote.
  */
-class EditQuoteModal extends Component {
+class EditModal extends Component {
   closeModal = () => {
     store.dispatch(closeEditModal())
   }
@@ -355,7 +293,7 @@ class EditQuoteModal extends Component {
   handleChange = (field, event) => {
     store.dispatch(
       setActiveQuote(
-        Object.assign({}, this.props.quoteRecord, { [field]: event.target.value }),
+        Object.assign({}, store.getState().activeQuote, { [field]: event.target.value }),
       ),
     )
   }
@@ -373,8 +311,9 @@ class EditQuoteModal extends Component {
   }
 
   render() {
-    const { activeQuote, editModal: { isOpen } } = store.getState()
+    const { activeQuote, quoteRecords, editModal: { isOpen } } = store.getState()
     const { quote, author, url, category } = activeQuote
+    const quoteExists = quoteRecords.has(activeQuote.id)
 
     return (
       <Modal
@@ -382,7 +321,7 @@ class EditQuoteModal extends Component {
         overlayClassName="modalOverlay"
         isOpen={isOpen}
         onRequestClose={this.closeModal}
-        contentLabel="Edit Quote"
+        contentLabel={quoteExists ? 'Edit Quote' : 'Add Quote'}
       >
         <h1 className="modal--heading">Edit Quote</h1>
         <hr className="modal--rule" />
@@ -401,7 +340,7 @@ class EditQuoteModal extends Component {
           >
             Save
           </button>
-          <DeleteButton onClick={this.handleDelete} />
+          {quoteExists ? <DeleteButton onClick={this.handleDelete} /> : null}
           <CancelButton onClick={this.closeModal} />
         </QuoteForm>
       </Modal>
@@ -432,8 +371,7 @@ class AppRoot extends Component {
         settings={settings}
         quoteRecords={quoteRecords}
       />,
-      <EditQuoteModal key="edit-modal" />,
-      <AddQuoteModal key="add-modal" />,
+      <EditModal key="edit-modal" />,
     ]
   }
 }

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -235,59 +235,47 @@ const QuoteForm = ({ quote, author, url, category, children, handleChange }) => 
 /*
  * A modal for editing the clicked-on quote.
  */
-class EditModal extends Component {
-  closeModal = () => {
-    dispatch(closeModal())
-  }
-
-  handleChange = (field, event) => {
+const EditModal = () => {
+  const { activeQuote, quoteRecords, modalIsOpen } = store.getState()
+  const handleClose = compose2(dispatch, closeModal)
+  const handleDelete = () => dispatch(deleteQuoteRecord(activeQuote.id))
+  const handleChange = (field, event) => {
     dispatch(patchActiveQuote({ [field]: event.target.value }))
   }
+  const quoteExists = quoteRecords.has(activeQuote.id)
 
-  handleSave = () => {
-    dispatch(putQuoteRecord(store.getState().activeQuote))
-  }
+  return (
+    <Modal
+      className="modal"
+      overlayClassName="modalOverlay"
+      isOpen={modalIsOpen}
+      onRequestClose={handleClose}
+      contentLabel={quoteExists ? 'Edit Quote' : 'Add Quote'}
+    >
+      <h1 className="modal--heading">Edit Quote</h1>
+      <hr className="modal--rule" />
 
-  handleDelete = () => {
-    dispatch(deleteQuoteRecord(store.getState().activeQuote.id))
-  }
-
-  render() {
-    const { activeQuote, quoteRecords, modalIsOpen } = store.getState()
-    const { quote, author, url, category } = activeQuote
-    const quoteExists = quoteRecords.has(activeQuote.id)
-
-    return (
-      <Modal
-        className="modal"
-        overlayClassName="modalOverlay"
-        isOpen={modalIsOpen}
-        onRequestClose={this.closeModal}
-        contentLabel={quoteExists ? 'Edit Quote' : 'Add Quote'}
+      <QuoteForm
+        quote={activeQuote.quote}
+        author={activeQuote.author}
+        url={activeQuote.url}
+        category={activeQuote.category}
+        handleChange={handleChange}
       >
-        <h1 className="modal--heading">Edit Quote</h1>
-        <hr className="modal--rule" />
-
-        <QuoteForm
-          quote={quote}
-          author={author}
-          url={url}
-          category={category}
-          handleChange={this.handleChange}
+        <button
+          type="button"
+          className="btn btn-save"
+          onClick={() => dispatch(putQuoteRecord(activeQuote))}
         >
-          <button
-            type="button"
-            className="btn btn-save"
-            onClick={this.handleSave}
-          >
-            Save
-          </button>
-          {quoteExists ? <DeleteButton onClick={this.handleDelete} /> : null}
-          <CancelButton onClick={this.closeModal} />
-        </QuoteForm>
-      </Modal>
-    )
-  }
+          Save
+        </button>
+        {quoteExists
+          ? <DeleteButton onClick={handleDelete} />
+          : null}
+        <CancelButton onClick={handleClose} />
+      </QuoteForm>
+    </Modal>
+  )
 }
 
 

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -28,7 +28,7 @@ import {
   saveQuoteRecords,
   deleteQuoteRecord,
 } from './actions'
-import { loadSettings, loadQuotes } from './util'
+import { compose2, loadSettings, loadQuotes } from './util'
 
 import 'Styles/options/style.scss'
 

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -21,7 +21,6 @@ import {
   updateSettings,
   updateQuoteRecords,
   putQuoteRecord,
-  // saveQuoteRecords,
   deleteQuoteRecord,
 } from './actions'
 import { compose2, loadSettings, loadQuotes } from './util'
@@ -277,9 +276,6 @@ const QuoteForm = ({ quote, author, url, category, children, handleChange }) => 
 )
 
 
-// TODO: make this a presentational component?
-// TODO: add a prop for whether or not to allow delete
-// TODO: parameterize title
 /*
  * A modal for editing the clicked-on quote.
  */
@@ -298,13 +294,11 @@ class EditModal extends Component {
 
   handleSave = () => {
     store.dispatch(putQuoteRecord(store.getState().activeQuote))
-    // store.dispatch(saveQuoteRecords())
     this.closeModal()
   }
 
   handleDelete = () => {
     store.dispatch(deleteQuoteRecord(store.getState().activeQuote.id))
-    // store.dispatch(saveQuoteRecords())
     this.closeModal()
   }
 

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -103,6 +103,9 @@ const QuotesSection = ({ quoteRecords }) => {
   )
 }
 
+/*
+ * Future home of a link to spur in the chrome store.
+ */
 const ChromeStoreLink = () => (
   <a className="link" href="https://chrome.google.com/webstore/category/extensions">
     <FontAwesomeIcon icon={faChrome} />
@@ -111,6 +114,9 @@ const ChromeStoreLink = () => (
   </a>
 )
 
+/*
+ * Future home of a link to spur in the firefox store.
+ */
 const FirefoxStoreLink = () => (
   <a className="link" href="https://addons.mozilla.org/en-US/firefox/">
     <FontAwesomeIcon icon={faFirefox} />

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -16,6 +16,7 @@ import reducers from './reducers'
 import {
   setActiveQuote,
   setNewActiveQuote,
+  patchActiveQuote,
   openModal,
   closeModal,
   updateSettings,
@@ -285,11 +286,7 @@ class EditModal extends Component {
   }
 
   handleChange = (field, event) => {
-    store.dispatch(
-      setActiveQuote(
-        Object.assign({}, store.getState().activeQuote, { [field]: event.target.value }),
-      ),
-    )
+    store.dispatch(patchActiveQuote({ [field]: event.target.value }))
   }
 
   handleSave = () => {

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -28,7 +28,9 @@ import { compose2, loadSettings, loadQuotes } from './util'
 
 import 'Styles/options/style.scss'
 
+
 const store = createStore(reducers)
+const { dispatch } = store
 
 
 /*
@@ -70,8 +72,8 @@ class EditQuoteButton extends Component {
   }
 
   handleClick = () => {
-    store.dispatch(setActiveQuote(this.props.quoteRecord))
-    store.dispatch(openModal())
+    dispatch(setActiveQuote(this.props.quoteRecord))
+    dispatch(openModal())
   }
 
   classes() {
@@ -110,8 +112,8 @@ class EditQuoteButton extends Component {
  */
 class AddQuoteButton extends Component {
   handleClick = () => {
-    store.dispatch(setNewActiveQuote())
-    store.dispatch(openModal())
+    dispatch(setNewActiveQuote())
+    dispatch(openModal())
   }
 
   render() {
@@ -282,19 +284,19 @@ const QuoteForm = ({ quote, author, url, category, children, handleChange }) => 
  */
 class EditModal extends Component {
   closeModal = () => {
-    store.dispatch(closeModal())
+    dispatch(closeModal())
   }
 
   handleChange = (field, event) => {
-    store.dispatch(patchActiveQuote({ [field]: event.target.value }))
+    dispatch(patchActiveQuote({ [field]: event.target.value }))
   }
 
   handleSave = () => {
-    store.dispatch(putQuoteRecord(store.getState().activeQuote))
+    dispatch(putQuoteRecord(store.getState().activeQuote))
   }
 
   handleDelete = () => {
-    store.dispatch(deleteQuoteRecord(store.getState().activeQuote.id))
+    dispatch(deleteQuoteRecord(store.getState().activeQuote.id))
   }
 
   render() {
@@ -342,8 +344,8 @@ class EditModal extends Component {
 class AppRoot extends Component {
   componentDidMount() {
     // TODO: move this stuff into the store
-    loadSettings().then(compose2(store.dispatch, updateSettings))
-    loadQuotes().then(compose2(store.dispatch, updateQuoteRecords))
+    loadSettings().then(compose2(dispatch, updateSettings))
+    loadQuotes().then(compose2(dispatch, updateQuoteRecords))
   }
 
   render() {

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -4,7 +4,6 @@ import Modal from 'react-modal'
 import classNames from 'classnames'
 import { createStore } from 'redux'
 import { connect } from 'react-redux'
-import PropTypes from 'prop-types'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -164,6 +164,19 @@ const OptionsPage = ({ settings, quotes }) => (
 )
 
 /*
+ * A save button for the modal.
+ */
+const SaveButton = ({ onClick }) => (
+  <button
+    type="button"
+    className="btn btn-save"
+    onClick={onClick}
+  >
+    Save
+  </button>
+)
+
+/*
  * A cancel button for the modals.
  */
 const CancelButton = ({ onClick }) => (
@@ -264,13 +277,7 @@ const EditModal = () => {
         category={activeQuote.category}
         handleChange={handleChange}
       >
-        <button
-          type="button"
-          className="btn btn-save"
-          onClick={() => dispatch(putQuote(activeQuote))}
-        >
-          Save
-        </button>
+        <SaveButton onClick={() => dispatch(putQuote(activeQuote))} />
         {quoteExists
           ? <DeleteButton onClick={handleDelete} />
           : null}

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -16,8 +16,8 @@ import reducers from './reducers'
 import {
   setActiveQuote,
   setNewActiveQuote,
-  openEditModal,
-  closeEditModal,
+  openModal,
+  closeModal,
   updateSettings,
   updateQuoteRecords,
   putQuoteRecord,
@@ -71,7 +71,7 @@ class EditQuoteButton extends Component {
 
   handleClick = () => {
     store.dispatch(setActiveQuote(this.props.quoteRecord))
-    store.dispatch(openEditModal())
+    store.dispatch(openModal())
   }
 
   classes() {
@@ -111,7 +111,7 @@ class EditQuoteButton extends Component {
 class AddQuoteButton extends Component {
   handleClick = () => {
     store.dispatch(setNewActiveQuote())
-    store.dispatch(openEditModal())
+    store.dispatch(openModal())
   }
 
   render() {
@@ -287,7 +287,7 @@ const QuoteForm = ({ quote, author, url, category, children, handleChange }) => 
  */
 class EditModal extends Component {
   closeModal = () => {
-    store.dispatch(closeEditModal())
+    store.dispatch(closeModal())
   }
 
   handleChange = (field, event) => {
@@ -311,7 +311,7 @@ class EditModal extends Component {
   }
 
   render() {
-    const { activeQuote, quoteRecords, editModal: { isOpen } } = store.getState()
+    const { activeQuote, quoteRecords, modalIsOpen } = store.getState()
     const { quote, author, url, category } = activeQuote
     const quoteExists = quoteRecords.has(activeQuote.id)
 
@@ -319,7 +319,7 @@ class EditModal extends Component {
       <Modal
         className="modal"
         overlayClassName="modalOverlay"
-        isOpen={isOpen}
+        isOpen={modalIsOpen}
         onRequestClose={this.closeModal}
         contentLabel={quoteExists ? 'Edit Quote' : 'Add Quote'}
       >

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -13,7 +13,7 @@ import { faChrome } from '@fortawesome/free-brands-svg-icons/faChrome'
 
 import * as actions from './actions'
 import reducers from './reducers'
-import { loadSettings, loadQuotes, wrapActions, polyfillBrowser } from './util'
+import { loadSettings, loadQuotes, polyfillBrowser } from './util'
 
 import 'Styles/options/style.scss'
 

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -236,21 +236,19 @@ const DeleteButton = ({ onClick }) => (
 /*
  * A parameterized input for the quote form.
  */
-const QuoteFormField = ({ name, value, handleChange }) => {
-  const lower = name.toLowerCase()
-  return [
-    <label key={`label-${lower}`} className="quoteForm--label" htmlFor={`id-${lower}`}>
+const QuoteFormField = ({ name, value, handleChange }) => (
+  <div className="quoteForm--field">
+    <label className="quoteForm--label" htmlFor={`id-${name}`}>
       {name}
-    </label>,
+    </label>
     <input
-      key={`input-${lower}`}
-      id={`id-${lower}`}
-      className="quoteForm--field"
+      id={`id-${name}`}
+      className="quoteForm--input"
       value={value}
-      onChange={event => handleChange(lower, event)}
-    />,
-  ]
-}
+      onChange={event => handleChange(name.toLowerCase(), event)}
+    />
+  </div>
+)
 
 
 /*
@@ -258,13 +256,15 @@ const QuoteFormField = ({ name, value, handleChange }) => {
  */
 const QuoteForm = ({ quote, author, url, category, children, handleChange }) => (
   <form className="quoteForm">
-    <label className="quoteForm--label" htmlFor="id-quote">Quote</label>
-    <textarea
-      id="id-quote"
-      className="quoteForm--field quoteForm--field-textarea"
-      value={quote}
-      onChange={event => handleChange('quote', event)}
-    />
+    <div className="quoteForm--field">
+      <label className="quoteForm--label" htmlFor="id-quote">Quote</label>
+      <textarea
+        id="id-quote"
+        className="quoteForm--input quoteForm--input-textarea"
+        value={quote}
+        onChange={event => handleChange('quote', event)}
+      />
+    </div>
 
     <QuoteFormField name="Author" value={author} handleChange={handleChange} />
     <QuoteFormField name="URL" value={url} handleChange={handleChange} />

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -22,7 +22,7 @@ import {
   closeAddModal,
   updateSettings,
   updateQuoteRecords,
-  updateQuoteRecord,
+  putQuoteRecord,
   // saveQuoteRecords,
   deleteQuoteRecord,
 } from './actions'
@@ -293,7 +293,7 @@ class AddQuoteModal extends Component {
   }
 
   handleSave = () => {
-    store.dispatch(updateQuoteRecord(store.getState().activeQuote))
+    store.dispatch(putQuoteRecord(store.getState().activeQuote))
     // store.dispatch(saveQuoteRecords())
     store.dispatch(closeAddModal())
   }
@@ -357,7 +357,7 @@ class EditQuoteModal extends Component {
   }
 
   handleSave = () => {
-    store.dispatch(updateQuoteRecord(store.getState().activeQuote))
+    store.dispatch(putQuoteRecord(store.getState().activeQuote))
     // store.dispatch(saveQuoteRecords())
     store.dispatch(closeEditModal())
   }

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -233,8 +233,26 @@ const DeleteButton = ({ onClick }) => (
   </button>
 )
 
+/*
+ * A parameterized input for the quote form.
+ */
+const QuoteFormField = ({ name, value, handleChange }) => {
+  const lower = name.toLowerCase()
+  return [
+    <label key={`label-${lower}`} className="quoteForm--label" htmlFor={`id-${lower}`}>
+      {name}
+    </label>,
+    <input
+      key={`input-${lower}`}
+      id={`id-${lower}`}
+      className="quoteForm--field"
+      value={value}
+      onChange={event => handleChange(lower, event)}
+    />,
+  ]
+}
 
-// TODO: make a function / HOC for the fields
+
 /*
  * A form for editing a quote. Buttons should be passed in as children.
  */
@@ -248,29 +266,9 @@ const QuoteForm = ({ quote, author, url, category, children, handleChange }) => 
       onChange={event => handleChange('quote', event)}
     />
 
-    <label className="quoteForm--label" htmlFor="id-author">Author</label>
-    <input
-      id="id-author"
-      className="quoteForm--field"
-      value={author}
-      onChange={event => handleChange('author', event)}
-    />
-
-    <label className="quoteForm--label" htmlFor="id-url">URL</label>
-    <input
-      id="id-url"
-      className="quoteForm--field"
-      value={url}
-      onChange={event => handleChange('url', event)}
-    />
-
-    <label className="quoteForm--label" htmlFor="id-category">Category</label>
-    <input
-      id="id-category"
-      className="quoteForm--field"
-      value={category}
-      onChange={event => handleChange('category', event)}
-    />
+    <QuoteFormField name="Author" value={author} handleChange={handleChange} />
+    <QuoteFormField name="URL" value={url} handleChange={handleChange} />
+    <QuoteFormField name="Category" value={category} handleChange={handleChange} />
 
     <div className="btnContainer">
       {children}

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -3,7 +3,8 @@ import ReactDOM from 'react-dom'
 import Modal from 'react-modal'
 import classNames from 'classnames'
 import { createStore } from 'redux'
-import { connect, Provider } from 'react-redux'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
@@ -469,6 +470,22 @@ const AppRoot = connect(
   },
 )(_AppRoot)
 
+
+
+class Provider extends Component {
+  getChildContext() {
+    return {
+      store: this.props.store // This corresponds to the `store` passed in as a prop
+    };
+  }
+  render() {
+    return this.props.children;
+  }
+}
+
+Provider.childContextTypes = {
+  store: PropTypes.object
+}
 
 const rootEl = document.getElementById('root')
 const store = createStore(reducers)

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -13,7 +13,7 @@ import { faChrome } from '@fortawesome/free-brands-svg-icons/faChrome'
 
 import * as actions from './actions'
 import reducers from './reducers'
-import { loadSettings, loadQuotes, wrapActions } from './util'
+import { loadSettings, loadQuotes, wrapActions, polyfillBrowser } from './util'
 
 import 'Styles/options/style.scss'
 
@@ -306,8 +306,8 @@ const AppRoot = () => {
 }
 
 
+polyfillBrowser()
 const render = () => ReactDOM.render(<AppRoot />, window.root)
 store.subscribe(render)
 Modal.setAppElement('#root')
-
 render()

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -1,4 +1,4 @@
-import React, { Component, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import Modal from 'react-modal'
 import { createStore } from 'redux'

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -289,7 +289,7 @@ const AppRoot = () => {
   const fetched = settings.size && quotes.size
 
   useEffect(() => {
-    if (fetched) { return }
+    if (fetched) return
     loadSettings().then(compose(dispatch, updateSettings))
     loadQuotes().then(compose(dispatch, updateQuotes))
   })

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -14,14 +14,9 @@ import { faChrome } from '@fortawesome/free-brands-svg-icons/faChrome'
 
 import reducers from './reducers'
 import {
-  setActiveQuote,
-  setNewActiveQuote,
-  patchActiveQuote,
-  closeModal,
-  updateSettings,
-  updateQuotes,
-  putQuote,
-  deleteQuote,
+  setActiveQuote, setNewActiveQuote, patchActiveQuote,
+  updateSettings, updateQuotes,
+  putQuote, deleteQuote, closeModal,
 } from './actions'
 import { loadSettings, loadQuotes } from './util'
 

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -294,12 +294,10 @@ class EditModal extends Component {
 
   handleSave = () => {
     store.dispatch(putQuoteRecord(store.getState().activeQuote))
-    this.closeModal()
   }
 
   handleDelete = () => {
     store.dispatch(deleteQuoteRecord(store.getState().activeQuote.id))
-    this.closeModal()
   }
 
   render() {

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -19,9 +19,9 @@ import {
   patchActiveQuote,
   closeModal,
   updateSettings,
-  updateQuoteRecords,
-  putQuoteRecord,
-  deleteQuoteRecord,
+  updateQuotes,
+  putQuote,
+  deleteQuote,
 } from './actions'
 import { loadSettings, loadQuotes } from './util'
 
@@ -55,15 +55,15 @@ const SettingsSection = () => (
 /*
  * A clickable displayed quote. Includes a pencil icon on hover.
  */
-const EditQuoteButton = ({ quoteRecord }) => (
+const EditQuoteButton = ({ quote }) => (
   <button
     type="button"
     className="editQuoteButton"
-    onClick={() => dispatch(setActiveQuote(quoteRecord))}
+    onClick={() => dispatch(setActiveQuote(quote))}
   >
     <div className="truncatedText" tabIndex="-1">
-      <span>{quoteRecord.quote}</span>
-      <span className="inlineAuthor">{` — ${quoteRecord.author}`}</span>
+      <span>{quote.text}</span>
+      <span className="inlineAuthor">{` — ${quote.author}`}</span>
     </div>
     <FontAwesomeIcon icon={faPencilAlt} className="editQuoteButton--pencil" />
   </button>
@@ -88,14 +88,14 @@ const AddQuoteButton = () => (
 /*
  * The quotes section of the options page. An editable list of stored quotes.
  */
-const QuotesSection = ({ quoteRecords }) => {
-  const values = Array.from(quoteRecords.values())
+const QuotesSection = ({ quotes }) => {
+  const values = Array.from(quotes.values())
   return (
     <section className="optionsSection">
-      {values.map(quoteRecord => (
+      {values.map(quote => (
         <EditQuoteButton
-          key={quoteRecord.id}
-          quoteRecord={quoteRecord}
+          key={quote.id}
+          quote={quote}
         />
       ))}
       <AddQuoteButton />
@@ -155,13 +155,13 @@ const LinksSection = () => (
 /*
  * The entire options page.
  */
-const OptionsPage = ({ settings, quoteRecords }) => (
+const OptionsPage = ({ settings, quotes }) => (
   <div className="optionsContainer">
     <h1 className="optionsHeading">Settings</h1>
     <SettingsSection settings={settings} />
 
     <h1 className="optionsHeading">Quotes</h1>
-    <QuotesSection quoteRecords={quoteRecords} />
+    <QuotesSection quotes={quotes} />
 
     <h1 className="optionsHeading">Links</h1>
     <LinksSection />
@@ -216,15 +216,15 @@ const QuoteFormField = ({ name, value, handleChange }) => (
 /*
  * A form for editing a quote. Buttons should be passed in as children.
  */
-const QuoteForm = ({ quote, author, url, category, children, handleChange }) => (
+const QuoteForm = ({ text, author, url, category, children, handleChange }) => (
   <form className="quoteForm">
     <div className="quoteForm--field">
-      <label className="quoteForm--label" htmlFor="id-quote">Quote</label>
+      <label className="quoteForm--label" htmlFor="id-text">Quote</label>
       <textarea
-        id="id-quote"
+        id="id-text"
         className="quoteForm--input quoteForm--input-textarea"
-        value={quote}
-        onChange={event => handleChange('quote', event)}
+        value={text}
+        onChange={event => handleChange('text', event)}
       />
     </div>
 
@@ -243,13 +243,13 @@ const QuoteForm = ({ quote, author, url, category, children, handleChange }) => 
  * A modal for editing the clicked-on quote.
  */
 const EditModal = () => {
-  const { activeQuote, quoteRecords, modalIsOpen } = getState()
+  const { activeQuote, quotes, modalIsOpen } = getState()
   const handleClose = compose(dispatch, closeModal)
-  const handleDelete = () => dispatch(deleteQuoteRecord(activeQuote.id))
+  const handleDelete = () => dispatch(deleteQuote(activeQuote.id))
   const handleChange = (field, event) => {
     dispatch(patchActiveQuote({ [field]: event.target.value }))
   }
-  const quoteExists = quoteRecords.has(activeQuote.id)
+  const quoteExists = quotes.has(activeQuote.id)
 
   return (
     <Modal
@@ -263,7 +263,7 @@ const EditModal = () => {
       <hr className="modal--rule" />
 
       <QuoteForm
-        quote={activeQuote.quote}
+        text={activeQuote.text}
         author={activeQuote.author}
         url={activeQuote.url}
         category={activeQuote.category}
@@ -272,7 +272,7 @@ const EditModal = () => {
         <button
           type="button"
           className="btn btn-save"
-          onClick={() => dispatch(putQuoteRecord(activeQuote))}
+          onClick={() => dispatch(putQuote(activeQuote))}
         >
           Save
         </button>
@@ -290,20 +290,20 @@ const EditModal = () => {
  * Loads the options page and holds state.
  */
 const AppRoot = () => {
-  const { settings, quoteRecords } = getState()
-  const fetched = settings.size && quoteRecords.size
+  const { settings, quotes } = getState()
+  const fetched = settings.size && quotes.size
 
   useEffect(() => {
     if (fetched) { return }
     loadSettings().then(compose(dispatch, updateSettings))
-    loadQuotes().then(compose(dispatch, updateQuoteRecords))
+    loadQuotes().then(compose(dispatch, updateQuotes))
   })
 
   return fetched ? [
     <OptionsPage
       key="opts"
       settings={settings}
-      quoteRecords={quoteRecords}
+      quotes={quotes}
     />,
     <EditModal key="edit-modal" />,
   ] : null

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import Modal from 'react-modal'
-import { createStore } from 'redux'
+import { createStore, bindActionCreators } from 'redux'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
@@ -24,7 +24,7 @@ const {
   setActiveQuote, setNewActiveQuote, patchActiveQuote,
   updateSettings, updateQuotes,
   putQuote, deleteQuote, closeModal
-} = wrapActions(actions, store.dispatch)
+} = bindActionCreators(actions, store.dispatch)
 
 
 /*

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -53,6 +53,7 @@ const SettingsSection = () => (
 )
 
 
+// TODO: use hooks for hover
 /*
  * A clickable displayed quote. Includes a pencil icon on hover.
  */
@@ -340,6 +341,8 @@ class AddQuoteModal extends Component {
 
 
 // TODO: make this a presentational component?
+// TODO: add a prop for whether or not to allow delete
+// TODO: parameterize title
 /*
  * A modal for editing the clicked-on quote.
  */
@@ -371,6 +374,7 @@ class EditQuoteModal extends Component {
   render() {
     const { activeQuote, editModal: { isOpen } } = store.getState()
     const { quote, author, url, category } = activeQuote
+
     return (
       <Modal
         className="modal"
@@ -410,6 +414,7 @@ class EditQuoteModal extends Component {
  */
 class AppRoot extends Component {
   componentDidMount() {
+    // TODO: move this stuff into the store
     loadSettings().then(compose2(store.dispatch, updateSettings))
     loadQuotes().then(compose2(store.dispatch, updateQuoteRecords))
   }

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -57,7 +57,7 @@ const SettingsSection = () => (
 const EditQuoteButton = ({ quoteRecord }) => (
   <button
     type="button"
-    className="editQuoteButton editQuoteButton-is-hovered"
+    className="editQuoteButton"
     onClick={() => dispatch(setActiveQuote(quoteRecord))}
   >
     <div className="truncatedText">

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -306,10 +306,8 @@ const AppRoot = () => {
 }
 
 
-const rootEl = document.getElementById('root')
-Modal.setAppElement('#root')
-const render = () => {
-  ReactDOM.render(<AppRoot />, rootEl)
-}
+const render = () => ReactDOM.render(<AppRoot />, window.root)
 store.subscribe(render)
+Modal.setAppElement('#root')
+
 render()

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -28,7 +28,7 @@ import 'Styles/options/style.scss'
 
 
 const store = createStore(reducers)
-const { dispatch } = store
+const { dispatch, getState } = store
 
 
 /*
@@ -236,7 +236,7 @@ const QuoteForm = ({ quote, author, url, category, children, handleChange }) => 
  * A modal for editing the clicked-on quote.
  */
 const EditModal = () => {
-  const { activeQuote, quoteRecords, modalIsOpen } = store.getState()
+  const { activeQuote, quoteRecords, modalIsOpen } = getState()
   const handleClose = compose2(dispatch, closeModal)
   const handleDelete = () => dispatch(deleteQuoteRecord(activeQuote.id))
   const handleChange = (field, event) => {
@@ -283,7 +283,7 @@ const EditModal = () => {
  * Loads the options page and holds state.
  */
 const AppRoot = () => {
-  const { settings, quoteRecords } = store.getState()
+  const { settings, quoteRecords } = getState()
   const fetched = settings.size && quoteRecords.size
 
   useEffect(() => {

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -60,7 +60,7 @@ const EditQuoteButton = ({ quoteRecord }) => (
     className="editQuoteButton"
     onClick={() => dispatch(setActiveQuote(quoteRecord))}
   >
-    <div className="truncatedText">
+    <div className="truncatedText" tabIndex="-1">
       <span>{quoteRecord.quote}</span>
       <span className="inlineAuthor">{` — ${quoteRecord.author}`}</span>
     </div>

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -285,6 +285,10 @@ const QuoteForm = ({ quote, author, url, category, children, handleChange }) => 
  * A modal for editing the clicked-on quote.
  */
 class AddQuoteModal extends Component {
+  closeModal = () => {
+    store.dispatch(closeAddModal())
+  }
+
   handleChange = (field, event) => {
     store.dispatch(
       setActiveQuote(
@@ -296,11 +300,7 @@ class AddQuoteModal extends Component {
   handleSave = () => {
     store.dispatch(putQuoteRecord(store.getState().activeQuote))
     // store.dispatch(saveQuoteRecords())
-    store.dispatch(closeAddModal())
-  }
-
-  closeModal = () => {
-    store.dispatch(closeAddModal())
+    this.closeModal()
   }
 
   render() {
@@ -362,13 +362,13 @@ class EditQuoteModal extends Component {
   handleSave = () => {
     store.dispatch(putQuoteRecord(store.getState().activeQuote))
     // store.dispatch(saveQuoteRecords())
-    store.dispatch(closeEditModal())
+    this.closeModal()
   }
 
   handleDelete = () => {
     store.dispatch(deleteQuoteRecord(store.getState().activeQuote.id))
     // store.dispatch(saveQuoteRecords())
-    store.dispatch(closeEditModal())
+    this.closeModal()
   }
 
   render() {

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import Modal from 'react-modal'
 import { createStore } from 'redux'
+import compose from 'compose-function'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
@@ -22,7 +23,7 @@ import {
   putQuoteRecord,
   deleteQuoteRecord,
 } from './actions'
-import { compose2, loadSettings, loadQuotes } from './util'
+import { loadSettings, loadQuotes } from './util'
 
 import 'Styles/options/style.scss'
 
@@ -237,7 +238,7 @@ const QuoteForm = ({ quote, author, url, category, children, handleChange }) => 
  */
 const EditModal = () => {
   const { activeQuote, quoteRecords, modalIsOpen } = getState()
-  const handleClose = compose2(dispatch, closeModal)
+  const handleClose = compose(dispatch, closeModal)
   const handleDelete = () => dispatch(deleteQuoteRecord(activeQuote.id))
   const handleChange = (field, event) => {
     dispatch(patchActiveQuote({ [field]: event.target.value }))
@@ -288,8 +289,8 @@ const AppRoot = () => {
 
   useEffect(() => {
     if (fetched) { return }
-    loadSettings().then(compose2(dispatch, updateSettings))
-    loadQuotes().then(compose2(dispatch, updateQuoteRecords))
+    loadSettings().then(compose(dispatch, updateSettings))
+    loadQuotes().then(compose(dispatch, updateQuoteRecords))
   })
 
   return fetched ? [

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -25,7 +25,7 @@ import {
   updateSettings,
   updateQuoteRecords,
   updateQuoteRecord,
-  saveQuoteRecords,
+  // saveQuoteRecords,
   deleteQuoteRecord,
 } from './actions'
 import { compose2, loadSettings, loadQuotes } from './util'

--- a/src/options.jsx
+++ b/src/options.jsx
@@ -497,5 +497,5 @@ const render = () => {
   ), rootEl)
 }
 
-render()
 store.subscribe(render)
+render()

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -27,6 +27,10 @@ const modalIsOpen = (state = false, action) => {
   switch (action.type) {
     case 'OPEN_MODAL':
       return true
+    case 'SET_ACTIVE_QUOTE':
+      return true
+    case 'SET_NEW_ACTIVE_QUOTE':
+      return true
     case 'CLOSE_MODAL':
       return false
     case 'PUT_QUOTE_RECORD':

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -85,5 +85,5 @@ export default combineReducers({
   activeQuote,
   modalIsOpen,
   settings,
-  quotes,
+  quotes
 })

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -3,7 +3,7 @@ import { polyfillBrowser } from './util'
 
 polyfillBrowser()
 
-const normalizedQuoteRecords = records => (
+const normalizedQuotes = records => (
   records.reduce((map, record, idx) => {
     map.set(idx, Object.assign({ id: idx }, record))
     return map
@@ -33,9 +33,9 @@ const modalIsOpen = (state = false, action) => {
       return true
     case 'CLOSE_MODAL':
       return false
-    case 'PUT_QUOTE_RECORD':
+    case 'PUT_QUOTE':
       return false
-    case 'DELETE_QUOTE_RECORD':
+    case 'DELETE_QUOTE':
       return false
     default:
       return state
@@ -51,28 +51,28 @@ const settings = (state = new Map(), action) => {
   }
 }
 
-const quoteRecords = (state = new Map(), action) => {
+const quotes = (state = new Map(), action) => {
   switch (action.type) {
-    case 'UPDATE_QUOTE_RECORDS': {
-      return normalizedQuoteRecords(action.payload)
+    case 'UPDATE_QUOTES': {
+      return normalizedQuotes(action.payload)
     }
-    case 'PUT_QUOTE_RECORD': {
+    case 'PUT_QUOTE': {
       const copy = new Map(state)
-      const quoteRecord = Object.assign({}, action.payload)
+      const quote = Object.assign({}, action.payload)
 
-      if (quoteRecord.id === 'new') {
-        quoteRecord.id = Math.random()
+      if (quote.id === 'new') {
+        quote.id = Math.random()
       }
-      copy.set(quoteRecord.id, quoteRecord)
+      copy.set(quote.id, quote)
       return copy
     }
-    case 'DELETE_QUOTE_RECORD': {
+    case 'DELETE_QUOTE': {
       const copy = new Map(state)
       copy.delete(action.payload)
       return copy
     }
     // TODO thunk it up
-    case 'SAVE_QUOTE_RECORDS': {
+    case 'SAVE_QUOTES': {
       browser.storage.local.set({ storedQuotes: Array.from(state.values()) })
       return state
     }
@@ -85,5 +85,5 @@ export default combineReducers({
   activeQuote,
   modalIsOpen,
   settings,
-  quoteRecords,
+  quotes,
 })

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -15,7 +15,7 @@ const activeQuote = (state = {}, action) => {
     case 'SET_ACTIVE_QUOTE':
       return action.payload
     case 'SET_NEW_ACTIVE_QUOTE': {
-      return { quote: '', author: '', url: '', category: '', id: Math.random() }
+      return { quote: '', author: '', url: '', category: '', id: 'new' }
     }
     default:
       return state
@@ -60,7 +60,11 @@ const quoteRecords = (state = new Map(), action) => {
     }
     case 'PUT_QUOTE_RECORD': {
       const copy = new Map(state)
-      const quoteRecord = action.payload
+      const quoteRecord = Object.assign({}, action.payload)
+
+      if (quoteRecord.id === 'new') {
+        quoteRecord.id = Math.random()
+      }
       copy.set(quoteRecord.id, quoteRecord)
       return copy
     }

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -14,9 +14,8 @@ const activeQuote = (state = {}, action) => {
   switch (action.type) {
     case 'SET_ACTIVE_QUOTE':
       return action.payload
-    case 'SET_NEW_ACTIVE_QUOTE': {
+    case 'SET_NEW_ACTIVE_QUOTE':
       return { quote: '', author: '', url: '', category: '', id: 'new' }
-    }
     default:
       return state
   }

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -22,12 +22,12 @@ const activeQuote = (state = {}, action) => {
   }
 }
 
-const editModal = (state = { isOpen: false }, action) => {
+const modalIsOpen = (state = false, action) => {
   switch (action.type) {
-    case 'OPEN_EDIT_MODAL':
-      return { isOpen: true }
-    case 'CLOSE_EDIT_MODAL':
-      return { isOpen: false }
+    case 'OPEN_MODAL':
+      return true
+    case 'CLOSE_MODAL':
+      return false
     default:
       return state
   }
@@ -74,7 +74,7 @@ const quoteRecords = (state = new Map(), action) => {
 
 export default combineReducers({
   activeQuote,
-  editModal,
+  modalIsOpen,
   settings,
   quoteRecords,
 })

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -16,6 +16,8 @@ const activeQuote = (state = {}, action) => {
       return action.payload
     case 'SET_NEW_ACTIVE_QUOTE':
       return { quote: '', author: '', url: '', category: '', id: 'new' }
+    case 'PATCH_ACTIVE_QUOTE':
+      return Object.assign({}, state, action.payload)
     default:
       return state
   }

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -58,7 +58,7 @@ const quoteRecords = (state = new Map(), action) => {
     case 'UPDATE_QUOTE_RECORDS': {
       return normalizedQuoteRecords(action.payload)
     }
-    case 'UPDATE_QUOTE_RECORD': {
+    case 'PUT_QUOTE_RECORD': {
       const copy = new Map(state)
       const quoteRecord = action.payload
       copy.set(quoteRecord.id, quoteRecord)

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,7 +1,4 @@
 import { combineReducers } from 'redux'
-import { polyfillBrowser } from './util'
-
-polyfillBrowser()
 
 const normalizedQuotes = records => (
   records.reduce((map, record, idx) => {

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -22,17 +22,6 @@ const activeQuote = (state = {}, action) => {
   }
 }
 
-const addModal = (state = { isOpen: false }, action) => {
-  switch (action.type) {
-    case 'OPEN_ADD_MODAL':
-      return { isOpen: true }
-    case 'CLOSE_ADD_MODAL':
-      return { isOpen: false }
-    default:
-      return state
-  }
-}
-
 const editModal = (state = { isOpen: false }, action) => {
   switch (action.type) {
     case 'OPEN_EDIT_MODAL':
@@ -85,7 +74,6 @@ const quoteRecords = (state = new Map(), action) => {
 
 export default combineReducers({
   activeQuote,
-  addModal,
   editModal,
   settings,
   quoteRecords,

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -28,6 +28,10 @@ const modalIsOpen = (state = false, action) => {
       return true
     case 'CLOSE_MODAL':
       return false
+    case 'PUT_QUOTE_RECORD':
+      return false
+    case 'DELETE_QUOTE_RECORD':
+      return false
     default:
       return state
   }

--- a/src/util.js
+++ b/src/util.js
@@ -47,8 +47,6 @@ export function polyfillBrowser() {
   }
 }
 
-polyfillBrowser()
-
 /**
  * Seeds browser storage with the included quotes.
  */

--- a/src/util.js
+++ b/src/util.js
@@ -33,7 +33,7 @@ export function polyfillBrowser() {
     runtime: {
       openOptionsPage: () => {
         document.location.href = '/options.html'
-      }
+      },
     },
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -49,23 +49,6 @@ async function seedStorage() {
 }
 
 /**
- * Returns string with leading nonword characters removed.
- */
-function trimStart(str) {
-  return str.replace(/^\W+/, '')
-}
-
-/**
- * Returns quote records sorted by quote. Ignores leading ellipsis.
- */
-// TODO: currently unused
-export const sortedQuoteRecords = records => (
-  records.sort((a, b) => (
-    trimStart(a.quote).localeCompare(trimStart(b.quote))
-  ))
-)
-
-/**
  * Reads a single key from browser storage and returns the value without the wrapper object.
  */
 export async function getOneKey(key) {

--- a/src/util.js
+++ b/src/util.js
@@ -5,10 +5,6 @@ const DEFAULT_SETTINGS = {
 
 const seeds = require('../assets/seeds.json')
 
-export function compose2(fn1, fn2) {
-  return (...args) => fn1(fn2(...args))
-}
-
 /**
  * Assigns browser shim unless browser is defined. Makes it possible to use
  * dev server.

--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,22 @@
+import compose from 'compose-function'
+
 const DEFAULT_SETTINGS = {
   theme: 'indexCard',
   wakeTime: '6 am'
 }
 
 const seeds = require('../assets/seeds.json')
+
+/*
+ * Given an object whose values are action creators, and a Redux store's dispatch function,
+ * returns a new object where each value is wrapped by dispatch.
+ */
+export function wrapActions(actions, dispatch) {
+  return Object.keys(actions).reduce((acc, key) => {
+    acc[key] = compose(dispatch, actions[key])
+    return acc
+  }, {})
+}
 
 /**
  * Assigns browser shim unless browser is defined. Makes it possible to use

--- a/src/util.js
+++ b/src/util.js
@@ -40,7 +40,7 @@ polyfillBrowser()
  * Seeds browser storage with the included quotes.
  */
 async function seedStorage() {
-  browser.storage.local.set({ storedQuotes: seeds })
+  browser.storage.local.set({ quotes: seeds })
 }
 
 /**
@@ -73,7 +73,7 @@ export async function loadSettings() {
  * included quotes and tries again.
  */
 export async function loadQuotes(stop) {
-  const quotes = await getOneKey('storedQuotes')
+  const quotes = await getOneKey('quotes')
 
   if (quotes || stop) {
     return quotes

--- a/src/util.js
+++ b/src/util.js
@@ -1,22 +1,9 @@
-import compose from 'compose-function'
-
 const DEFAULT_SETTINGS = {
   theme: 'indexCard',
   wakeTime: '6 am'
 }
 
 const seeds = require('../assets/seeds.json')
-
-/*
- * Given an object whose values are action creators, and a Redux store's dispatch function,
- * returns a new object where each value is wrapped by dispatch.
- */
-export function wrapActions(actions, dispatch) {
-  return Object.keys(actions).reduce((acc, key) => {
-    acc[key] = compose(dispatch, actions[key])
-    return acc
-  }, {})
-}
 
 /**
  * Assigns browser shim unless browser is defined. Makes it possible to use

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,6 @@
 const DEFAULT_SETTINGS = {
   theme: 'indexCard',
-  wakeTime: '6 am',
+  wakeTime: '6 am'
 }
 
 const seeds = require('../assets/seeds.json')
@@ -23,14 +23,14 @@ export function polyfillBrowser() {
           // note: assumes setting object with single key
           const key = Object.keys(obj)[0]
           return localStorage.setItem(key, JSON.stringify({ [key]: obj[key] }))
-        },
-      },
+        }
+      }
     },
     runtime: {
       openOptionsPage: () => {
         document.location.href = '/options.html'
-      },
-    },
+      }
+    }
   }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -41,7 +41,6 @@ polyfillBrowser()
  */
 async function seedStorage() {
   browser.storage.local.set({ storedQuotes: seeds })
-  return true
 }
 
 /**
@@ -80,5 +79,6 @@ export async function loadQuotes(stop) {
     return quotes
   }
 
-  return await seedStorage() && loadQuotes(true)
+  await seedStorage()
+  return loadQuotes(true)
 }

--- a/src/util.js
+++ b/src/util.js
@@ -5,6 +5,10 @@ const DEFAULT_SETTINGS = {
 
 const seeds = require('../assets/seeds.json')
 
+export function compose2(fn1, fn2) {
+  return (...args) => fn1(fn2(...args))
+}
+
 /**
  * Assigns browser shim unless browser is defined. Makes it possible to use
  * dev server.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,7 @@ module.exports = {
     new CleanWebpackPlugin(['dist']),
     new CopyWebpackPlugin([
       { from: 'assets/images/*.png', to: '[name].[ext]' },
+      { from: 'assets/manifest.json', to: 'manifest.json' },
     ]),
     new HtmlWebpackPlugin({
       filename: 'index.html',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,69 +10,69 @@ module.exports = {
   devtool: 'source-map',
 
   devServer: {
-    contentBase: path.join(__dirname, 'dist'),
+    contentBase: path.join(__dirname, 'dist')
   },
 
   resolve: {
     alias: {
-      Styles: path.resolve(__dirname, 'assets', 'styles'),
-    },
+      Styles: path.resolve(__dirname, 'assets', 'styles')
+    }
   },
 
   entry: {
     index: './src/app.jsx',
-    options: './src/options.jsx',
+    options: './src/options.jsx'
   },
 
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js',
+    filename: '[name].js'
   },
 
   module: {
     rules: [{
       test: /\.jsx$/,
       exclude: /node_modules/,
-      use: ['babel-loader'],
+      use: ['babel-loader']
     }, {
       test: /\.scss$/,
-      use: ['style-loader', 'css-loader', 'sass-loader'],
+      use: ['style-loader', 'css-loader', 'sass-loader']
     }, {
       test: /\.css$/,
-      use: ['style-loader', 'css-loader'],
+      use: ['style-loader', 'css-loader']
     }, {
       test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-      loader: 'url-loader?limit=10000&mimetype=application/font-woff',
+      loader: 'url-loader?limit=10000&mimetype=application/font-woff'
     }, {
       test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-      loader: 'file-loader',
-    }],
+      loader: 'file-loader'
+    }]
   },
 
   plugins: [
     new CleanWebpackPlugin(['dist']),
     new CopyWebpackPlugin([
       { from: 'assets/images/*.png', to: '[name].[ext]' },
-      { from: 'assets/manifest.json', to: 'manifest.json' },
+      { from: 'assets/manifest.json', to: 'manifest.json' }
     ]),
     new HtmlWebpackPlugin({
       filename: 'index.html',
       chunks: ['index'],
-      template: './src/template.html',
+      template: './src/template.html'
     }),
     new HtmlWebpackPlugin({
       filename: 'options.html',
       chunks: ['options'],
-      template: './src/template.html',
+      template: './src/template.html'
     }),
     new GoogleFontsPlugin({
       fonts: [
         { family: 'Work Sans', variants: ['300', '400', '500'] },
         { family: 'Staatliches', variants: ['400'], subsets: ['latin'] },
         { family: 'PT Mono', variants: ['400'] },
-        { family: 'Overpass Mono', variants: ['300', '400'] },
+        { family: 'Overpass Mono', variants: ['300', '400'] }
       ],
-      formats: ['woff2'],
-    }),
-  ],
+      formats: ['woff2']
+    })
+  ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const GoogleFontsPlugin = require('@beyonk/google-fonts-webpack-plugin')
 module.exports = {
   mode: 'development',
 
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
 
   devServer: {
     contentBase: path.join(__dirname, 'dist'),


### PR DESCRIPTION
This PR does a lot to simplify things, but the big one is to stop using react-redux `connect`, which I'll discuss below.

Other things this PR does:

- Terminology: `quoteRecord` is now `quote` everywhere, and what was `quote` (the field within the record) is now called `text`.
- All components are now functions.
- Components no longer chain calls to action creators. Treating actions as composable primitives breaks the idea of the app as having a fixed set of actions, which I've come to see as undesirable. Now, e.g. saving a quote also closes the modal, *in the reducers.*
- Index page's `AppRoot` uses hooks for the `quoteBox` open / closed state.
- Hooks are awesome.
- Options page components close over `store.getState` and use it directly. They also close over & use the (already-bound) action creators directly. (Index page doesn't need Redux.)
- `EditQuoteButton` now renders the same thing on hover. CSS is used to hide the pencil icon, and React doesn't track the hover state.
- There's only one modal now.
- Extracted `QuoteFormField`
- Code style: switched away from trailing quote style. Making diffs more readable at the expense of the code seems like the tail wagging the dog.

### Removing `connect`

As I see it, most of the boilerplate required for Redux comes about because React and Redux are separate projects, and it's up to the programmer to bridge them at component boundaries.

The noisiness of mapping state & actions to props is simply not necessary for the project at this stage. It's a ton of code that doesn't buy anything.

My components are part of my application, so I have no problem with them reading application *state* -- no more than I do with instance methods reading instance variables. Walling them off doesn't simplify reasoning about the app, but what does is *putting all state in one place and only updating it through a closed set of actions.*

Also, overloading what `props` are by passing application state through them strikes me as a hack (albeit one that enables pruning during renders).

There's a trade-off: by subscribing the top-level render to `store` and rendering everything all the time, I may be setting myself up for slowdowns on very large lists, but as of right now I've seen no noticeable impact on performance builds. Things have gotten way simpler -- the size of `options.jsx` has gone down by half, I'm happy to make the trade.

(I also want to see too what degree things feel different with solutions like Elm, MobX, the meiosis pattern, and maybe Vue.)